### PR TITLE
Remove delete-jobs for charts in the standard catalog

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.6
+version: 0.8.7
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/templates/delete_job.yaml
+++ b/charts/datadoc/templates/delete_job.yaml
@@ -1,5 +1,0 @@
-{{ include "library-chart.deleteJobCron" . }}
----
-{{ include "library-chart.deleteJobRoleBinding" . }}
----
-{{ include "library-chart.deleteJobServiceAccount" . }}

--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.20
+version: 0.3.21
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-playground/templates/delete_job.yaml
+++ b/charts/jupyter-playground/templates/delete_job.yaml
@@ -1,5 +1,0 @@
-{{ include "library-chart.deleteJobCron" . }}
----
-{{ include "library-chart.deleteJobRoleBinding" . }}
----
-{{ include "library-chart.deleteJobServiceAccount" . }}

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.13
+version: 0.3.14
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter/templates/delete_job.yaml
+++ b/charts/jupyter/templates/delete_job.yaml
@@ -1,5 +1,0 @@
-{{ include "library-chart.deleteJobCron" . }}
----
-{{ include "library-chart.deleteJobRoleBinding" . }}
----
-{{ include "library-chart.deleteJobServiceAccount" . }}

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.12
+version: 0.3.13
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio/templates/delete_job.yaml
+++ b/charts/rstudio/templates/delete_job.yaml
@@ -1,5 +1,0 @@
-{{ include "library-chart.deleteJobCron" . }}
----
-{{ include "library-chart.deleteJobRoleBinding" . }}
----
-{{ include "library-chart.deleteJobServiceAccount" . }}

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.17
+version: 0.3.18
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/templates/delete_job.yaml
+++ b/charts/vscode-python/templates/delete_job.yaml
@@ -1,5 +1,0 @@
-{{ include "library-chart.deleteJobCron" . }}
----
-{{ include "library-chart.deleteJobRoleBinding" . }}
----
-{{ include "library-chart.deleteJobServiceAccount" . }}


### PR DESCRIPTION
This will prevent services from being killed automatically. For stability reasons we will be performing delete jobs manually for starters...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/21)
<!-- Reviewable:end -->
