### PR TITLE
only generate helm docs if envvar defined

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
           sudo mv helm-docs /usr/local/sbin
 
       - name: Generate Helm docs
+        if: env.GENERATE_DOCS != ''
         run: |
           helm-docs -o README.md
           if [[ `git status --porcelain` ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
           sudo mv helm-docs /usr/local/sbin
 
       - name: Generate Helm docs
-        if: env.GENERATE_DOCS != ''
+        if: vars.GENERATE_DOCS != ''
         run: |
           helm-docs -o README.md
           if [[ `git status --porcelain` ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
           sudo mv helm-docs /usr/local/sbin
 
       - name: Generate Helm docs
-        if: vars.GENERATE_DOCS != ''
+        if: vars.GENERATE_DOCS == '1'
         run: |
           helm-docs -o README.md
           if [[ `git status --porcelain` ]]; then


### PR DESCRIPTION
The 'GENERATE_DOCS' var won't be defined in the standard
repo so the docs aren't generated there and
will ensure we don't get diverging forks
over time

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/31)
<!-- Reviewable:end -->
