### PR TITLE
Reduce Datadoc resource requests

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.3
+version: 0.9.4
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -40,10 +40,7 @@
               "description": "Datadoc-versjon",
               "type": "string",
               "default": "v0",
-              "listEnum": [
-                "v0",
-                "master"
-              ],
+              "listEnum": ["v0", "master"],
               "render": "list",
               "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$"
             }
@@ -84,9 +81,7 @@
           "description": "Hvilket team og tilgangsgruppe sine datatilganger som aktiveres",
           "render": "list",
           "default": "",
-          "listEnum": [
-            ""
-          ],
+          "listEnum": [""],
           "x-onyxia": {
             "overwriteDefaultWith": "user.decodedIdToken.dapla.groups.0",
             "overwriteListEnumWith": "user.decodedIdToken.dapla.groups"
@@ -110,7 +105,7 @@
               "description": "The amount of CPU guaranteed",
               "title": "CPU",
               "type": "string",
-              "default": "1000m",
+              "default": "100m",
               "render": "slider",
               "sliderMin": 50,
               "sliderMax": 8000,
@@ -125,7 +120,7 @@
               "description": "The amount of memory guaranteed",
               "title": "Memory",
               "type": "string",
-              "default": "8Gi",
+              "default": "1Gi",
               "render": "slider",
               "sliderMin": 1,
               "sliderMax": 600,


### PR DESCRIPTION
## Summary

After observing Datadoc in use, we can see that the resource consumption is much lower than the current requests. This applies even when opening a relatively large dataset. This should scale even to extremely large datasets since we use the PyArrow `pq.read_schema(f)` method, which accesses only the metadata of the parquet file, not the data itself.

## Resource usage example

![Screenshot 2024-09-09 at 13 35 00](https://github.com/user-attachments/assets/8ba66bef-136a-4614-95f7-66cb91cbe43a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/63)
<!-- Reviewable:end -->
