### PR TITLE
vscode-python: make dapla-team mandatory

### DIFF
--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.7
+version: 0.7.8
 
 
 dependencies:

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -15,7 +15,7 @@
               "type": "boolean",
               "title": "Aktiver",
               "description": "Aktiver datatilgang",
-              "default": true
+              "default": true,
               "hidden": {
                 "value" : true
               }

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -15,7 +15,10 @@
               "type": "boolean",
               "title": "Aktiver",
               "description": "Aktiver datatilgang",
-              "default": false
+              "default": true
+              "hidden": {
+                "value" : true
+              }
             },
             "mountStandard": {
               "type": "boolean",
@@ -34,14 +37,10 @@
           "title": "Team og tilgangsgruppe",
           "description": "Hvilket team og tilgangsgruppe sine datatilganger som aktiveres",
           "render": "list",
-          "default": "",
+          "default": "dapla-felles-developers",
           "listEnum": [
             ""
           ],
-          "x-onyxia": {
-            "overwriteDefaultWith": "user.decodedIdToken.dapla.groups.0",
-            "overwriteListEnumWith": "user.decodedIdToken.dapla.groups"
-          },
           "hidden": {
             "value": false,
             "path": "dapla/buckets/enabled"

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -151,7 +151,7 @@ dapla:
   buckets:
     enabled: false
     mountStandard: true
-  group: ""
+  group: "dapla-felles-developers"
 
 deleteJob:
   enabled: true


### PR DESCRIPTION
always enable dapla team and change default to 'dapla-felles-developers'

internal ref: https://statistics-norway.atlassian.net/browse/DPSTAT-1137

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/160)
<!-- Reviewable:end -->
