### PR TITLE
Remove .security.password from all values.yaml files

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.30
+version: 0.9.31
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/values.yaml
+++ b/charts/datadoc/values.yaml
@@ -8,7 +8,6 @@ tjeneste:
     pullPolicy: Always
 
 security:
-  password: "changeme"
   networkPolicy:
     enabled: false
     from: []

--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 
 
 dependencies:

--- a/charts/jdemetra/values.yaml
+++ b/charts/jdemetra/values.yaml
@@ -7,7 +7,6 @@ tjeneste:
   pullPolicy: Always
 
 security:
-  password: "changeme"
   networkPolicy:
     enabled: false
     from: []

--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.20
+version: 0.6.21
 
 
 dependencies:

--- a/charts/jupyter-playground/values.yaml
+++ b/charts/jupyter-playground/values.yaml
@@ -6,7 +6,6 @@ tjeneste:
     pullPolicy: IfNotPresent
 
 security:
-  password: "changeme"
   networkPolicy:
     enabled: false
     from: []

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.34
+version: 0.0.35
 
 
 dependencies:

--- a/charts/jupyter-pyspark/values.yaml
+++ b/charts/jupyter-pyspark/values.yaml
@@ -6,7 +6,6 @@ tjeneste:
     pullPolicy: IfNotPresent
 
 security:
-  password: "changeme"
   networkPolicy:
     enabled: false
     from: []

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.23
+version: 0.7.24
 
 
 dependencies:

--- a/charts/jupyter/values.yaml
+++ b/charts/jupyter/values.yaml
@@ -6,7 +6,6 @@ tjeneste:
     pullPolicy: IfNotPresent
 
 security:
-  password: "changeme"
   networkPolicy:
     enabled: false
     from: []

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.20
+version: 0.6.21
 
 
 dependencies:

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -6,7 +6,6 @@ tjeneste:
     pullPolicy: IfNotPresent
 
 security:
-  password: "changeme"
   networkPolicy:
     enabled: false
     from: []

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.36
+version: 0.7.37
 
 
 dependencies:

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -6,7 +6,6 @@ tjeneste:
     pullPolicy: IfNotPresent
 
 security:
-  password: "changeme"
   networkPolicy:
     enabled: false
     from: []


### PR DESCRIPTION
This field is not in values.schema.json, we do not use passwords for our services and the field can in some cases lead to undesired results (e.g. when onyxia-janitor accidentally caused all services to show the "Copy password" dialogue on startup)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/218)
<!-- Reviewable:end -->
