### PR TITLE
jupyter: bump image version

### DIFF
--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.29
+version: 0.7.30
 
 
 dependencies:

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -28,10 +28,10 @@
           "title": "Versjon",
           "description": "Versjon av Python og R i tjenesten",
           "type": "string",
-          "default": "r4.4.0-py311-2025.02.26T15_48Z",
+          "default": "r4.4.0-py311-2025.03.14T13_34Z",
           "listEnum": [
-            "r4.4.0-py312-2025.02.26T15_47Z",
-            "r4.4.0-py311-2025.02.26T15_48Z"
+            "r4.4.0-py312-2025.03.14T13_33Z",
+            "r4.4.0-py311-2025.03.14T13_34Z"
           ],
           "render": "list",
           "pattern": "^[a-zA-Z0-9-_./]+(:[a-z0-9-_.]+)?$"

--- a/charts/jupyter/values.yaml
+++ b/charts/jupyter/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: "r4.4.0-py311-2025.02.26T15_48Z"
+  version: "r4.4.0-py311-2025.03.14T13_34Z"
   image:
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
now uses image with ssb-project-cli version
that supports poetry >= 2.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/230)
<!-- Reviewable:end -->
