### PR TITLE
Set memory limit equal to memory request

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.31
+version: 0.10.0
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/templates/statefulset.yaml
+++ b/charts/datadoc/templates/statefulset.yaml
@@ -109,11 +109,7 @@ spec:
               cpu: {{ .Values.ressurser.requests.cpu }}
               memory: {{ .Values.ressurser.requests.memory }}
             limits: 
-              # Memory limit = min(mem_requested * 1.5, mem_requested + 4)
-              {{- with .Values.ressurser.requests}}
-              {{- $requestedmem := .memory | trimSuffix "Gi" | float64}}
-              memory: {{ min (mulf 1.5 $requestedmem) (add 4.0 $requestedmem) | int | toString | printf "%vGi" }}
-              {{- end }}
+              memory: {{ .Values.ressurser.requests.memory }}
         - {{ include "library-chart.oauth2ProxyPod" . | indent 10 | trim }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.16
+version: 1.1.0
 
 
 dependencies:

--- a/charts/jdemetra/templates/statefulset.yaml
+++ b/charts/jdemetra/templates/statefulset.yaml
@@ -113,10 +113,8 @@ spec:
             requests:
               cpu: {{ .Values.ressurser.requests.cpu }}
               memory: {{ .Values.ressurser.requests.memory }}
-            limits: 
-              # Memory limit = min(mem_requested * 1.5, mem_requested + 4)
-              {{- $requestedmem := .Values.ressurser.requests.memory | trimSuffix "Gi" | float64}}
-              memory: {{ min (mulf 1.5 $requestedmem) (add 4.0 $requestedmem) | int | toString | printf "%vGi" }}
+            limits:
+              memory: {{ .Values.ressurser.requests.memory }}
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user}}/work
               subPath: work

--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.23
+version: 0.7.0
 
 
 dependencies:

--- a/charts/jupyter-playground/templates/statefulset.yaml
+++ b/charts/jupyter-playground/templates/statefulset.yaml
@@ -186,9 +186,7 @@ spec:
               cpu: {{ .Values.resources.cpu }}
               memory: {{ .Values.resources.memory }}
             limits: 
-              # Memory limit = min(mem_requested * 1.5, mem_requested + 4)
-              {{- $requestedmem := .Values.resources.memory | trimSuffix "Gi" | float64}}
-              memory: {{ min (mulf 1.5 $requestedmem) (add 4.0 $requestedmem) | int | toString | printf "%vGi" }}
+              memory: {{ .Values.resources.memory }}
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user}}/work
               subPath: work

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.37
+version: 0.1.0
 
 
 dependencies:

--- a/charts/jupyter-pyspark/templates/statefulset.yaml
+++ b/charts/jupyter-pyspark/templates/statefulset.yaml
@@ -205,10 +205,8 @@ spec:
             requests:
               cpu: {{ .Values.resources.cpu }}
               memory: {{ .Values.resources.memory }}
-            limits: 
-              # Memory limit = min(mem_requested * 1.5, mem_requested + 4)
-              {{- $requestedmem := .Values.resources.memory | trimSuffix "Gi" | float64}}
-              memory: {{ min (mulf 1.5 $requestedmem) (add 4.0 $requestedmem) | int | toString | printf "%vGi" }}
+            limits:
+              memory: {{ .Values.resources.memory }}
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user}}/work
               subPath: work

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.30
+version: 0.8.0
 
 
 dependencies:

--- a/charts/jupyter/templates/statefulset.yaml
+++ b/charts/jupyter/templates/statefulset.yaml
@@ -189,10 +189,8 @@ spec:
             requests:
               cpu: {{ .Values.resources.cpu }}
               memory: {{ .Values.resources.memory }}
-            limits: 
-              # Memory limit = min(mem_requested * 1.5, mem_requested + 4)
-              {{- $requestedmem := .Values.resources.memory | trimSuffix "Gi" | float64}}
-              memory: {{ min (mulf 1.5 $requestedmem) (add 4.0 $requestedmem) | int | toString | printf "%vGi" }}
+            limits:
+              memory: {{ .Values.resources.memory }}
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user}}/work
               subPath: work

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.24
+version: 0.7.0
 
 
 dependencies:

--- a/charts/rstudio/templates/statefulset.yaml
+++ b/charts/rstudio/templates/statefulset.yaml
@@ -158,10 +158,8 @@ spec:
             requests:
               cpu: {{ .Values.resources.cpu }}
               memory: {{ .Values.resources.memory }}
-            limits: 
-              # Memory limit = min(mem_requested * 1.5, mem_requested + 4)
-              {{- $requestedmem := .Values.resources.memory | trimSuffix "Gi" | float64}}
-              memory: {{ min (mulf 1.5 $requestedmem) (add 4.0 $requestedmem) | int | toString | printf "%vGi" }}
+            limits:
+              memory: {{ .Values.resources.memory }}
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user}}/work
               subPath: work

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.42
+version: 0.8.0
 
 
 dependencies:

--- a/charts/vscode-python/templates/statefulset.yaml
+++ b/charts/vscode-python/templates/statefulset.yaml
@@ -165,10 +165,8 @@ spec:
             requests:
               cpu: {{ .Values.resources.cpu }}
               memory: {{ .Values.resources.memory }}
-            limits: 
-              # Memory limit = min(mem_requested * 1.5, mem_requested + 4)
-              {{- $requestedmem := .Values.resources.memory | trimSuffix "Gi" | float64}}
-              memory: {{ min (mulf 1.5 $requestedmem) (add 4.0 $requestedmem) | int | toString | printf "%vGi" }}
+            limits:
+              memory: {{ .Values.resources.memory }}
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user}}/work
               subPath: work


### PR DESCRIPTION
Mitigate that node is allocated over capacity. This make sure the services for the users are more stable if everyone is using max of their requested memory (and also easier for the user to expect behavior).

Internal ref: [DPSKY-997]

[DPSKY-997]: https://statistics-norway.atlassian.net/browse/DPSKY-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/231)
<!-- Reviewable:end -->
