### PR TITLE
Update all services to with new ssb project

### DIFF
--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 
 
 dependencies:

--- a/charts/jupyter-playground/values.schema.json
+++ b/charts/jupyter-playground/values.schema.json
@@ -28,10 +28,10 @@
           "title": "Versjon",
           "description": "Versjon av Python og R i tjenesten",
           "type": "string",
-          "default": "r4.4.0-py311-2025.03.18T16_04Z",
+          "default": "r4.4.0-py311-2025.03.21T09_47Z" ,
           "listEnum": [
-            "r4.4.0-py312-2025.03.18T16_04Z",
-            "r4.4.0-py311-2025.03.18T16_04Z"
+            "r4.4.0-py312-2025.03.21T09_46Z",
+            "r4.4.0-py311-2025.03.21T09_47Z"
           ],
           "render": "list",
           "pattern": "^[a-zA-Z0-9-_./]+(:[a-z0-9-_.]+)?$"

--- a/charts/jupyter-playground/values.yaml
+++ b/charts/jupyter-playground/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: "r4.4.0-py311-2025.03.18T16_04Z"
+  version: "r4.4.0-py311-2025.03.21T09_47Z"
   image:
     pullPolicy: IfNotPresent
 

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 
 dependencies:

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -28,10 +28,10 @@
           "title": "Versjon",
           "description": "Versjon av Python og R i tjenesten",
           "type": "string",
-          "default": "py311-spark3.5.3-2025.03.18T15_54Z",
+          "default": "py311-spark3.5.3-2025.03.21T09_40Z",
           "listEnum": [
-            "py312-spark3.5.3-2025.03.18T15_55Z",
-            "py311-spark3.5.3-2025.03.18T15_54Z"
+            "py312-spark3.5.3-2025.03.21T09_39Z",
+            "py311-spark3.5.3-2025.03.21T09_40Z"
           ],
           "render": "list",
           "pattern": "^[a-zA-Z0-9-_./]+(:[a-z0-9-_.]+)?$"

--- a/charts/jupyter-pyspark/values.yaml
+++ b/charts/jupyter-pyspark/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: "py311-spark3.5.3-2025.03.18T15_54Z"
+  version: "py311-spark3.5.3-2025.03.21T09_40Z"
   image:
     pullPolicy: IfNotPresent
 

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 
 dependencies:

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -28,10 +28,10 @@
           "title": "Versjon",
           "description": "Versjon av Python og R i tjenesten",
           "type": "string",
-          "default": "r4.4.0-py311-2025.03.18T16_04Z",
+          "default": "r4.4.0-py311-2025.03.21T09_47Z",
           "listEnum": [
-            "r4.4.0-py312-2025.03.18T16_05Z",
-            "r4.4.0-py311-2025.03.18T16_04Z"
+            "r4.4.0-py312-2025.03.21T09_49Z",
+            "r4.4.0-py311-2025.03.21T09_47Z"
           ],
           "render": "list",
           "pattern": "^[a-zA-Z0-9-_./]+(:[a-z0-9-_.]+)?$"

--- a/charts/jupyter/values.yaml
+++ b/charts/jupyter/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: "r4.4.0-py311-2025.03.18T16_04Z"
+  version: "r4.4.0-py311-2025.03.21T09_47Z"
   image:
     pullPolicy: IfNotPresent
 

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 
 dependencies:

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -28,10 +28,10 @@
           "title": "Versjon",
           "description": "Versjon av Python og R i tjenesten",
           "type": "string",
-          "default": "py311-2025.03.18T15_55Z",
+          "default": "py311-2025.03.21T09_39Z",
           "listEnum": [
-            "py311-2025.03.18T15_55Z",
-            "py312-2025.03.18T15_55Z"
+            "py311-2025.03.21T09_39Z",
+            "py312-2025.03.21T09_39Z"
           ],
           "render": "list",
           "pattern": "^[a-zA-Z0-9-_./]+(:[a-z0-9-_.]+)?$"

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: "py311-2025.03.18T15_55Z"
+  version: "py311-2025.03.21T09_39Z"
   image:
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
All services that use python now supports a version of ssb-project (and project template) that itself supports poetry 2.0. 

Internal ref: https://statistics-norway.atlassian.net/browse/DPSTAT-1246