### PR TITLE
Remove edit and admin options from .kubernetes.role

### DIFF
--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2
+version: 0.10.3
 
 
 dependencies:

--- a/charts/jupyter-playground/values.schema.json
+++ b/charts/jupyter-playground/values.schema.json
@@ -258,9 +258,7 @@
           "description": "bind your service account to this kubernetes default role",
           "default": "view",
           "enum": [
-            "view",
-            "edit",
-            "admin"
+            "view"
           ],
           "x-onyxia": {
             "hidden": true

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 
 dependencies:

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -255,9 +255,7 @@
           "description": "bind your service account to this kubernetes default role",
           "default": "view",
           "enum": [
-            "view",
-            "edit",
-            "admin"
+            "view"
           ],
           "x-onyxia": {
             "hidden": true

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2
+version: 0.10.3
 
 
 dependencies:

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -255,9 +255,7 @@
           "description": "bind your service account to this kubernetes default role",
           "default": "view",
           "enum": [
-            "view",
-            "edit",
-            "admin"
+            "view"
           ],
           "x-onyxia": {
             "hidden": true

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 
 
 dependencies:

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -326,9 +326,7 @@
           "description": "bind your service account to this kubernetes default role",
           "default": "view",
           "enum": [
-            "view",
-            "edit",
-            "admin"
+            "view"
           ],
           "x-onyxia": {
             "hidden": true

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2
+version: 0.10.3
 
 
 dependencies:

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -238,9 +238,7 @@
           "description": "bind your service account to this kubernetes default role",
           "default": "view",
           "enum": [
-            "view",
-            "edit",
-            "admin"
+            "view"
           ],
           "x-onyxia": {
             "hidden": true


### PR DESCRIPTION
Leaving these in allows the user to start a service with admin rights in their namespace

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/253)
<!-- Reviewable:end -->
