### PR TITLE
Bump version of library chart

### DIFF
--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -28,5 +28,5 @@ version: 0.10.3
 
 dependencies:
   - name: library-chart
-    version: 4.3.1
+    version: 4.3.3
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -23,10 +23,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2
+version: 0.10.3
 
 
 dependencies:
   - name: library-chart
-    version: 4.3.0
+    version: 4.3.1
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jupyter-playground/values.schema.json
+++ b/charts/jupyter-playground/values.schema.json
@@ -252,19 +252,6 @@
           "x-onyxia": {
             "hidden": true
           }
-        },
-        "role": {
-          "type": "string",
-          "description": "bind your service account to this kubernetes default role",
-          "default": "view",
-          "enum": [
-            "view",
-            "edit",
-            "admin"
-          ],
-          "x-onyxia": {
-            "hidden": true
-          }
         }
       }
     },

--- a/charts/jupyter-playground/values.yaml
+++ b/charts/jupyter-playground/values.yaml
@@ -97,7 +97,6 @@ serviceAccount:
 
 kubernetes:
   enabled: false
-  role: "view"
 
 podAnnotations: {}
 

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -29,5 +29,5 @@ version: 0.4.3
 
 dependencies:
   - name: library-chart
-    version: 4.3.1
+    version: 4.3.3
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,10 +24,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 
 dependencies:
   - name: library-chart
-    version: 4.3.0
+    version: 4.3.1
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -249,19 +249,6 @@
           "x-onyxia": {
             "hidden": true
           }
-        },
-        "role": {
-          "type": "string",
-          "description": "bind your service account to this kubernetes default role",
-          "default": "view",
-          "enum": [
-            "view",
-            "edit",
-            "admin"
-          ],
-          "x-onyxia": {
-            "hidden": true
-          }
         }
       }
     },

--- a/charts/jupyter-pyspark/values.yaml
+++ b/charts/jupyter-pyspark/values.yaml
@@ -97,7 +97,6 @@ serviceAccount:
 
 kubernetes:
   enabled: false
-  role: "view"
 
 podAnnotations: {}
 

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -28,5 +28,5 @@ version: 0.10.3
 
 dependencies:
   - name: library-chart
-    version: 4.3.1
+    version: 4.3.3
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -23,10 +23,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2
+version: 0.10.3
 
 
 dependencies:
   - name: library-chart
-    version: 4.3.0
+    version: 4.3.1
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -249,19 +249,6 @@
           "x-onyxia": {
             "hidden": true
           }
-        },
-        "role": {
-          "type": "string",
-          "description": "bind your service account to this kubernetes default role",
-          "default": "view",
-          "enum": [
-            "view",
-            "edit",
-            "admin"
-          ],
-          "x-onyxia": {
-            "hidden": true
-          }
         }
       }
     },

--- a/charts/jupyter/values.yaml
+++ b/charts/jupyter/values.yaml
@@ -35,7 +35,6 @@ environment:
 userAttributes:
   environmentVariableName: OIDC_TOKEN
   userAttribute: "access_token"
-  value: ""
 
 dapla:
   sourceData:

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -28,5 +28,5 @@ version: 0.9.3
 
 dependencies:
   - name: library-chart
-    version: 4.3.1
+    version: 4.3.3
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -23,10 +23,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 
 
 dependencies:
   - name: library-chart
-    version: 4.3.0
+    version: 4.3.1
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -320,19 +320,6 @@
           "x-onyxia": {
             "hidden": true
           }
-        },
-        "role": {
-          "type": "string",
-          "description": "bind your service account to this kubernetes default role",
-          "default": "view",
-          "enum": [
-            "view",
-            "edit",
-            "admin"
-          ],
-          "x-onyxia": {
-            "hidden": true
-          }
         }
       }
     },

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -81,7 +81,6 @@ serviceAccount:
 
 kubernetes:
   enabled: true
-  role: "view"
 
 podAnnotations: {}
 

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -27,5 +27,5 @@ version: 0.10.3
 
 dependencies:
   - name: library-chart
-    version: 4.3.1
+    version: 4.3.3
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,10 +22,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2
+version: 0.10.3
 
 
 dependencies:
   - name: library-chart
-    version: 4.3.0
+    version: 4.3.1
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -232,19 +232,6 @@
           "x-onyxia": {
             "hidden": true
           }
-        },
-        "role": {
-          "type": "string",
-          "description": "bind your service account to this kubernetes default role",
-          "default": "view",
-          "enum": [
-            "view",
-            "edit",
-            "admin"
-          ],
-          "x-onyxia": {
-            "hidden": true
-          }
         }
       }
     },

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -87,7 +87,6 @@ environment:
 
 kubernetes:
   enabled: true
-  role: "view"
 
 podAnnotations: {}
 


### PR DESCRIPTION
New version of the chart hardcodes the Kubernetes cluster role, so we remove it from the schema. Tested in `experimental`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/254)
<!-- Reviewable:end -->
