### PR TITLE
fix: Use overwriteSchemaWith as overwriteDefaultWith is deprecated

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.1
+version: 0.14.0
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -260,14 +260,14 @@
       "type": "object",
       "form": true,
       "title": "Ingress Details",
+      "overwriteSchemaWith": "dapla/istio.json",
       "properties": {
         "enabled": {
           "description": "Enable istio ingress",
           "type": "boolean",
           "default": true,
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.enabled"
+            "hidden": true
           }
         },
         "gateways": {
@@ -275,8 +275,7 @@
           "type": "array",
           "title": "Istio gateways",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.gateways"
+            "hidden": true
           },
           "default": []
         },
@@ -285,8 +284,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+            "hidden": true
           }
         },
         "extraHostname": {
@@ -295,8 +293,7 @@
           "title": "Extra hostname",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "region.customValues.extraHostname"
+            "hidden": true
           }
         },
         "serviceSubDomain": {
@@ -305,8 +302,7 @@
           "title": "Service subdomain",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0"
+            "hidden": true
           }
         }
       }

--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.5.0
 
 
 dependencies:

--- a/charts/jdemetra/values.schema.json
+++ b/charts/jdemetra/values.schema.json
@@ -270,14 +270,14 @@
       "type": "object",
       "form": true,
       "title": "Ingress Details",
+      "overwriteSchemaWith": "dapla/istio.json",
       "properties": {
         "enabled": {
           "description": "Enable istio ingress",
           "type": "boolean",
           "default": true,
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.enabled"
+            "hidden": true
           }
         },
         "gateways": {
@@ -285,8 +285,7 @@
           "type": "array",
           "title": "Istio gateways",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.gateways"
+            "hidden": true
           },
           "default": []
         },
@@ -295,8 +294,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+            "hidden": true
           }
         },
         "extraHostname": {
@@ -305,8 +303,7 @@
           "title": "Extra hostname",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "region.customValues.extraHostname"
+            "hidden": true
           }
         },
         "serviceSubDomain": {
@@ -315,8 +312,7 @@
           "title": "Service subdomain",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0"
+            "hidden": true
           }
         }
       }

--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.13.0
 
 
 dependencies:

--- a/charts/jupyter-playground/values.schema.json
+++ b/charts/jupyter-playground/values.schema.json
@@ -259,14 +259,14 @@
       "type": "object",
       "form": true,
       "title": "Ingress Details",
+      "overwriteSchemaWith": "dapla/istio.json",
       "properties": {
         "enabled": {
           "description": "Enable istio ingress",
           "type": "boolean",
           "default": true,
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.enabled"
+            "hidden": true
           }
         },
         "gateways": {
@@ -274,8 +274,7 @@
           "type": "array",
           "title": "Istio gateways",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.gateways"
+            "hidden": true
           },
           "default": []
         },
@@ -284,8 +283,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+            "hidden": true
           }
         },
         "extraHostname": {
@@ -294,8 +292,7 @@
           "title": "Extra hostname",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "region.customValues.extraHostname"
+            "hidden": true
           }
         },
         "serviceSubDomain": {
@@ -304,8 +301,7 @@
           "title": "Service subdomain",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0"
+            "hidden": true
           }
         }
       }

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.7.0
 
 
 dependencies:

--- a/charts/jupyter-pyspark/values.schema.json
+++ b/charts/jupyter-pyspark/values.schema.json
@@ -256,14 +256,14 @@
       "type": "object",
       "form": true,
       "title": "Ingress Details",
+      "overwriteSchemaWith": "dapla/istio.json",
       "properties": {
         "enabled": {
           "description": "Enable istio ingress",
           "type": "boolean",
           "default": true,
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.enabled"
+            "hidden": true
           }
         },
         "gateways": {
@@ -271,8 +271,7 @@
           "type": "array",
           "title": "Istio gateways",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.gateways"
+            "hidden": true
           },
           "default": []
         },
@@ -281,8 +280,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+            "hidden": true
           }
         },
         "extraHostname": {
@@ -291,8 +289,7 @@
           "title": "Extra hostname",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "region.customValues.extraHostname"
+            "hidden": true
           }
         },
         "serviceSubDomain": {
@@ -301,8 +298,7 @@
           "title": "Service subdomain",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0"
+            "hidden": true
           }
         }
       }

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.13.0
 
 
 dependencies:

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -256,14 +256,14 @@
       "type": "object",
       "form": true,
       "title": "Ingress Details",
+      "overwriteSchemaWith": "dapla/istio.json",
       "properties": {
         "enabled": {
           "description": "Enable istio ingress",
           "type": "boolean",
           "default": true,
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.enabled"
+            "hidden": true
           }
         },
         "gateways": {
@@ -271,8 +271,7 @@
           "type": "array",
           "title": "Istio gateways",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.gateways"
+            "hidden": true
           },
           "default": []
         },
@@ -281,8 +280,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+            "hidden": true
           }
         },
         "extraHostname": {
@@ -291,8 +289,7 @@
           "title": "Extra hostname",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "region.customValues.extraHostname"
+            "hidden": true
           }
         },
         "serviceSubDomain": {
@@ -301,8 +298,7 @@
           "title": "Service subdomain",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0"
+            "hidden": true
           }
         }
       }

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 0.12.0
 
 
 dependencies:

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -327,14 +327,14 @@
       "type": "object",
       "form": true,
       "title": "Ingress Details",
+      "overwriteSchemaWith": "dapla/istio.json",
       "properties": {
         "enabled": {
           "description": "Enable istio ingress",
           "type": "boolean",
           "default": true,
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.enabled"
+            "hidden": true
           }
         },
         "gateways": {
@@ -342,8 +342,7 @@
           "type": "array",
           "title": "Istio gateways",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.gateways"
+            "hidden": true
           },
           "default": []
         },
@@ -352,8 +351,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+            "hidden": true
           }
         },
         "extraHostname": {
@@ -362,8 +360,7 @@
           "title": "Extra hostname",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "region.customValues.extraHostname"
+            "hidden": true
           }
         },
         "serviceSubDomain": {
@@ -372,8 +369,7 @@
           "title": "Service subdomain",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0"
+            "hidden": true
           }
         }
       }

--- a/charts/vardef-forvaltning/Chart.yaml
+++ b/charts/vardef-forvaltning/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 dependencies:
   - name: library-chart

--- a/charts/vardef-forvaltning/values.schema.json
+++ b/charts/vardef-forvaltning/values.schema.json
@@ -289,14 +289,14 @@
       "type": "object",
       "form": true,
       "title": "Ingress Details",
+      "overwriteSchemaWith": "dapla/istio.json",
       "properties": {
         "enabled": {
           "description": "Enable istio ingress",
           "type": "boolean",
           "default": true,
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.enabled"
+            "hidden": true
           }
         },
         "gateways": {
@@ -304,8 +304,7 @@
           "type": "array",
           "title": "Istio gateways",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.gateways"
+            "hidden": true
           },
           "default": []
         },
@@ -314,8 +313,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+            "hidden": true
           }
         },
         "extraHostname": {
@@ -324,8 +322,7 @@
           "title": "Extra hostname",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "region.customValues.extraHostname"
+            "hidden": true
           }
         },
         "serviceSubDomain": {
@@ -334,8 +331,7 @@
           "title": "Service subdomain",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0"
+            "hidden": true
           }
         }
       }

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.13.0
 
 
 dependencies:

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -239,14 +239,14 @@
       "type": "object",
       "form": true,
       "title": "Ingress Details",
+      "overwriteSchemaWith": "dapla/istio.json",
       "properties": {
         "enabled": {
           "description": "Enable istio ingress",
           "type": "boolean",
           "default": true,
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.enabled"
+            "hidden": true
           }
         },
         "gateways": {
@@ -254,8 +254,7 @@
           "type": "array",
           "title": "Istio gateways",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "k8s.istio.gateways"
+            "hidden": true
           },
           "default": []
         },
@@ -264,8 +263,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0.{{k8s.domain}}"
+            "hidden": true
           }
         },
         "extraHostname": {
@@ -274,8 +272,7 @@
           "title": "Extra hostname",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "region.customValues.extraHostname"
+            "hidden": true
           }
         },
         "serviceSubDomain": {
@@ -284,8 +281,7 @@
           "title": "Service subdomain",
           "default": "",
           "x-onyxia": {
-            "hidden": true,
-            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}-0"
+            "hidden": true
           }
         }
       }


### PR DESCRIPTION

Such that we can set custom values also for the istio properties (`extraHostname`).
internal ref: [DPSKY-1048]