### PR TITLE
fix: Use library chart instead of custom file that is prone to not stay updated

### DIFF
--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1
 
 
 dependencies:

--- a/charts/jdemetra/templates/simpleproxyclient.yaml
+++ b/charts/jdemetra/templates/simpleproxyclient.yaml
@@ -1,10 +1,1 @@
-apiVersion: dapla.ssb.no/v1alpha1
-kind: SimpleProxyClient
-metadata:
-  name: {{ include "library-chart.fullname" . }}
-  labels: 
-  {{- include "library-chart.labels" . | nindent 4 }}
-spec:
-  redirectUris:
-    - "https://{{ .Values.istio.hostname }}/oauth2/callback"
-  secretName: {{ include "library-chart.daplaSimpleProxyClientSecretName" . | quote }}
+{{ include "library-chart.daplaSimpleProxyClient" . }}

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.13.1
 
 
 dependencies:

--- a/charts/rstudio/templates/simpleproxyclient.yaml
+++ b/charts/rstudio/templates/simpleproxyclient.yaml
@@ -1,10 +1,1 @@
-apiVersion: dapla.ssb.no/v1alpha1
-kind: SimpleProxyClient
-metadata:
-  name: {{ include "library-chart.fullname" . }}
-  labels: 
-  {{- include "library-chart.labels" . | nindent 4 }}
-spec:
-  redirectUris:
-    - "https://{{ .Values.istio.hostname }}/oauth2/callback"
-  secretName: {{ include "library-chart.daplaSimpleProxyClientSecretName" . | quote }}
+{{ include "library-chart.daplaSimpleProxyClient" . }}

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.14.1
 
 
 dependencies:

--- a/charts/vscode-python/templates/simpleproxyclient.yaml
+++ b/charts/vscode-python/templates/simpleproxyclient.yaml
@@ -1,10 +1,1 @@
-apiVersion: dapla.ssb.no/v1alpha1
-kind: SimpleProxyClient
-metadata:
-  name: {{ include "library-chart.fullname" . }}
-  labels: 
-  {{- include "library-chart.labels" . | nindent 4 }}
-spec:
-  redirectUris:
-    - "https://{{ .Values.istio.hostname }}/oauth2/callback"
-  secretName: {{ include "library-chart.daplaSimpleProxyClientSecretName" . | quote }}
+{{ include "library-chart.daplaSimpleProxyClient" . }}


### PR DESCRIPTION
This fix issue where users think that updating library chart should work for all serivces

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/264)
<!-- Reviewable:end -->
