### PR TITLE
Update url to dapla manual

### DIFF
--- a/charts/datadoc/values.yaml
+++ b/charts/datadoc/values.yaml
@@ -28,7 +28,7 @@ environment:
   user: onyxia
   group: users
   DATADOC_STATISTICAL_SUBJECT_SOURCE_URL: "https://www.ssb.no/xp/_/service/mimir/subjectStructurStatistics"
-  DAPLA_MANUAL_NAMING_STANDARD_URL: "https://probable-waddle-o4w1og1.pages.github.io/statistikkere/navnestandard-datalagring.html"
+  DAPLA_MANUAL_NAMING_STANDARD_URL: "https://manual.dapla.ssb.no/statistikkere/navnestandard.html"
 
 
 features:


### PR DESCRIPTION
Environment value for `DAPLA_MANUAL_NAMING_STANDARD_URL` was outdated