### PR TITLE
Update library-chart version

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -21,13 +21,11 @@ sources:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
-
+version: 0.15.2
 dependencies:
   - name: library-chart
-    version: 4.4.2
+    version: 4.4.8
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -3,7 +3,7 @@ name: jdemetra
 description: Verktøy for sesongjustering og tidsserie-analyse utviklet i samarbeid med Eurostat.
 icon: https://avatars.githubusercontent.com/u/10142886
 keywords:
-  - JDemetra  # TODO: Change 'home' to link to Dapla Manual
+  - JDemetra # TODO: Change 'home' to link to Dapla Manual
 home: https://manual.dapla.ssb.no/statistikkere/jdemetra.html
 sources:
   - https://github.com/statisticsnorway/dapla-lab-images
@@ -17,14 +17,11 @@ sources:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
-
-
+version: 1.7.1
 dependencies:
   - name: library-chart
-    version: 4.4.3
+    version: 4.4.8
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -3,7 +3,7 @@ name: jdemetra
 description: Verktøy for sesongjustering og tidsserie-analyse utviklet i samarbeid med Eurostat.
 icon: https://avatars.githubusercontent.com/u/10142886
 keywords:
-  - JDemetra # TODO: Change 'home' to link to Dapla Manual
+  - JDemetra  # TODO: Change 'home' to link to Dapla Manual
 home: https://manual.dapla.ssb.no/statistikkere/jdemetra.html
 sources:
   - https://github.com/statisticsnorway/dapla-lab-images

--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -19,14 +19,11 @@ sources:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.9
-
-
+version: 0.15.10
 dependencies:
   - name: library-chart
-    version: 4.4.6
+    version: 4.4.8
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jupyter-pyspark/Chart.yaml
+++ b/charts/jupyter-pyspark/Chart.yaml
@@ -20,14 +20,11 @@ sources:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.7
-
-
+version: 0.11.8
 dependencies:
   - name: library-chart
-    version: 4.4.6
+    version: 4.4.8
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -19,14 +19,11 @@ sources:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.9
-
-
+version: 0.15.10
 dependencies:
   - name: library-chart
-    version: 4.4.6
+    version: 4.4.8
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -19,14 +19,11 @@ sources:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.4
-
-
+version: 0.14.5
 dependencies:
   - name: library-chart
-    version: 4.4.4
+    version: 4.4.8
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/vardef-forvaltning/Chart.yaml
+++ b/charts/vardef-forvaltning/Chart.yaml
@@ -21,13 +21,11 @@ sources:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
-
+version: 0.8.3
 dependencies:
   - name: library-chart
-    version: 4.4.4
+    version: 4.4.8
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -18,14 +18,11 @@ sources:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.6
-
-
+version: 0.15.7
 dependencies:
   - name: library-chart
-    version: 4.4.6
+    version: 4.4.8
     repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library


### PR DESCRIPTION
Update to use latest version of library-chart because of changes to where OAuth2 Proxy image is located, related to bitnami's upcoming removal of images.

Bumped chart version with: `yq -i '.version |= (split(".") | .[-1] |= ((. tag = "!!int") + 1) | join("."))'`
Set library-chart version with: `yq -i '.dependencies[] (| select(.name == "library-chart")).version |= "4.4.8"'`

Internal-ref: [DPSKY-1148]

[DPSKY-1148]: https://statistics-norway.atlassian.net/browse/DPSKY-1148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/296)
<!-- Reviewable:end -->
