### PR TITLE
vscode-ai: update image

### DIFF
--- a/charts/vscode-ai/Chart.yaml
+++ b/charts/vscode-ai/Chart.yaml
@@ -14,7 +14,7 @@ sources:
   - https://github.com/statisticsnorway/dapla-lab-images
   - https://github.com/statisticsnorway/dapla-lab-helm-charts-library
 type: application
-version: 0.18.8
+version: 0.18.9
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/vscode-ai/values.schema.json
+++ b/charts/vscode-ai/values.schema.json
@@ -28,8 +28,8 @@
           "title" : "Versjon",
           "description" : "Versjon av Python og R i tjenesten",
           "type" : "string",
-          "default" : "r4.4.0-py313-2026.06.10T14_36Z",
-          "listEnum" : [ "r4.4.0-py313-2026.06.10T14_36Z" ],
+          "default" : "r4.4.0-py313-2026.06.11T08_46Z",
+          "listEnum" : [ "r4.4.0-py313-2026.06.11T08_46Z" ],
           "render" : "list",
           "pattern" : "^[a-zA-Z0-9-_.:/]+$"
         },

--- a/charts/vscode-ai/values.yaml
+++ b/charts/vscode-ai/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: r4.4.0-py313-2026.06.10T14_36Z
+  version: r4.4.0-py313-2026.06.11T08_46Z
   image:
     pullPolicy: IfNotPresent
 security:


### PR DESCRIPTION
image now no longer contains opencode
configuration, this is mounted as a configmap
defined in the helm chart instead

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/390)
<!-- Reviewable:end -->
