### PR TITLE
bump image versions

### DIFF
--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/statisticsnorway/dapla-lab-helm-charts-library
   - https://github.com/statisticsnorway/dapla-lab-images
 type: application
-version: 0.17.13
+version: 0.17.14
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/jupyter-playground/values.schema.json
+++ b/charts/jupyter-playground/values.schema.json
@@ -28,8 +28,8 @@
           "title" : "Versjon",
           "description" : "Versjon av Python og R i tjenesten",
           "type" : "string",
-          "default" : "r4.4.0-py313-2026.06.02T13_48Z",
-          "listEnum" : [ "r4.4.0-py313-2026.06.02T13_48Z" ],
+          "default" : "r4.4.0-py313-2026.06.18T13_19Z",
+          "listEnum" : [ "r4.4.0-py313-2026.06.18T13_19Z" ],
           "render" : "list",
           "pattern" : "^[a-zA-Z0-9-_.:/]+$"
         },

--- a/charts/jupyter-playground/values.yaml
+++ b/charts/jupyter-playground/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: r4.4.0-py313-2026.06.02T13_48Z
+  version: r4.4.0-py313-2026.06.18T13_19Z
   image:
     pullPolicy: IfNotPresent
 security:

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/statisticsnorway/dapla-lab-helm-charts-library
   - https://github.com/statisticsnorway/dapla-lab-images
 type: application
-version: 0.18.14
+version: 0.18.15
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -28,8 +28,8 @@
           "title" : "Versjon",
           "description" : "Versjon av Python og R i tjenesten",
           "type" : "string",
-          "default" : "r4.4.0-py313-2026.06.02T13_47Z",
-          "listEnum" : [ "r4.4.0-py313-2026.06.02T13_47Z" ],
+          "default" : "r4.4.0-py313-2026.06.18T13_20Z",
+          "listEnum" : [ "r4.4.0-py313-2026.06.18T13_20Z" ],
           "render" : "list",
           "pattern" : "^[a-zA-Z0-9-_.:/]+$"
         },

--- a/charts/jupyter/values.yaml
+++ b/charts/jupyter/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: r4.4.0-py313-2026.06.02T13_47Z
+  version: r4.4.0-py313-2026.06.18T13_20Z
   image:
     pullPolicy: IfNotPresent
 security:

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/statisticsnorway/dapla-lab-helm-charts-library
   - https://github.com/statisticsnorway/dapla-lab-images
 type: application
-version: 0.15.8
+version: 0.15.9
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -116,7 +116,7 @@
           "title" : "Versjon",
           "description" : "Versjon av Python og R i tjenesten",
           "type" : "string",
-          "default" : "r4.3.3-2026.06.18T13_08Z",
+          "default" : "r4.4.0-2026.06.18T13_08Z",
           "listEnum" : [ "r4.3.3-2026.06.18T13_08Z", "r4.4.0-2026.06.18T13_08Z" ],
           "render" : "list",
           "pattern" : "^[a-zA-Z0-9-_.:/]+$"

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -116,8 +116,8 @@
           "title" : "Versjon",
           "description" : "Versjon av Python og R i tjenesten",
           "type" : "string",
-          "default" : "r4.4.0-2026.03.05T07_59Z",
-          "listEnum" : [ "r4.3.3-2026.03.05T07_58Z", "r4.4.0-2026.03.05T07_59Z" ],
+          "default" : "r4.3.3-2026.06.18T13_08Z",
+          "listEnum" : [ "r4.3.3-2026.06.18T13_08Z", "r4.4.0-2026.06.18T13_08Z" ],
           "render" : "list",
           "pattern" : "^[a-zA-Z0-9-_.:/]+$"
         },

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: r4.4.0-2026.03.05T07_59Z
+  version: r4.4.0-2026.06.18T13_08Z
   image:
     pullPolicy: IfNotPresent
 security:

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: r4.3.3-2026.06.18T13_08Z
+  version: r4.4.0-2026.03.05T07_59Z
   image:
     pullPolicy: IfNotPresent
 security:

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: r4.3.3-2026.03.05T07_58Z
+  version: r4.3.3-2026.06.18T13_08Z
   image:
     pullPolicy: IfNotPresent
 security:

--- a/charts/vscode-ai/Chart.yaml
+++ b/charts/vscode-ai/Chart.yaml
@@ -14,7 +14,7 @@ sources:
   - https://github.com/statisticsnorway/dapla-lab-images
   - https://github.com/statisticsnorway/dapla-lab-helm-charts-library
 type: application
-version: 0.18.11
+version: 0.18.12
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/vscode-ai/values.schema.json
+++ b/charts/vscode-ai/values.schema.json
@@ -28,8 +28,8 @@
           "title" : "Versjon",
           "description" : "Versjon av Python og R i tjenesten",
           "type" : "string",
-          "default" : "r4.4.0-py313-2026.06.17T12_37Z",
-          "listEnum" : [ "r4.4.0-py313-2026.06.17T12_37Z" ],
+          "default" : "r4.4.0-py313-2026.06.18T13_42Z",
+          "listEnum" : [ "r4.4.0-py313-2026.06.18T13_42Z" ],
           "render" : "list",
           "pattern" : "^[a-zA-Z0-9-_.:/]+$"
         },

--- a/charts/vscode-ai/values.yaml
+++ b/charts/vscode-ai/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: r4.4.0-py313-2026.06.17T12_37Z
+  version: r4.4.0-py313-2026.06.18T13_42Z
   image:
     pullPolicy: IfNotPresent
 security:

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/statisticsnorway/dapla-lab-images
   - https://github.com/statisticsnorway/dapla-lab-helm-charts-library
 type: application
-version: 0.18.1
+version: 0.18.2
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -28,8 +28,8 @@
           "title" : "Versjon",
           "description" : "Versjon av Python og R i tjenesten",
           "type" : "string",
-          "default" : "r4.4.0-py313-2026.06.05T06_01Z",
-          "listEnum" : [ "r4.4.0-py313-2026.06.05T06_01Z" ],
+          "default" : "r4.4.0-py313-2026.06.18T13_18Z",
+          "listEnum" : [ "r4.4.0-py313-2026.06.18T13_18Z" ],
           "render" : "list",
           "pattern" : "^[a-zA-Z0-9-_.:/]+$"
         },

--- a/charts/vscode-python/values.yaml
+++ b/charts/vscode-python/values.yaml
@@ -1,7 +1,7 @@
 global:
   suspend: false
 tjeneste:
-  version: r4.4.0-py313-2026.06.05T06_01Z
+  version: r4.4.0-py313-2026.06.18T13_18Z
   image:
     pullPolicy: IfNotPresent
 security:


### PR DESCRIPTION
for jupyter, jupyter-playground, rstudio, vscode and vscode-ai

this adds the `libuv` dependency needed for the R `fs` package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-lab-helm-charts-standard-test/393)
<!-- Reviewable:end -->
